### PR TITLE
fix log retention comment

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -50,7 +50,7 @@ if (logDir) {
         datePattern: 'YYYY-MM-DD',
         dirname: logDir + '/error', // log file /logs/error/*.log in save
         filename: `%DATE%.log`,
-        maxFiles: 31, // 30 Days saved
+        maxFiles: 31, // 31 Days saved
         handleExceptions: true,
         json: false,
         zippedArchive: true,


### PR DESCRIPTION
## Summary
- update comment in logger to note that 31 days of logs are saved

## Testing
- `npm test` *(fails: jest not found)*