### PR TITLE
Update CI trigger paths

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -3,9 +3,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'package.json'
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   publish_image:


### PR DESCRIPTION
## Summary
- run publish workflow on all pushes except markdown-only changes

## Testing
- `npm test` *(fails: jest not found)*